### PR TITLE
feat: translate site based on browser language

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -11,6 +11,9 @@ async function fetchProfileData() {
         language = 'pt';
     }
 
+    // Define o atributo "lang" do documento para refletir o idioma ativo
+    document.documentElement.lang = language;
+
     // Define o caminho do arquivo JSON baseado no idioma
     const url = `data/profile_${language}.json`;
 
@@ -29,14 +32,3 @@ async function fetchProfileData() {
         return null;
     }
 }
-
-// Exemplo de uso da função
-fetchProfileData().then(profileData => {
-    if (profileData) {
-        // Aqui você pode manipular os dados do perfil e atualizar a interface da página
-        console.log(profileData);
-    } else {
-        // Lógica para caso os dados não sejam carregados
-        console.log("Não foi possível carregar os dados do perfil.");
-    }
-});

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -362,7 +362,8 @@ function updateProfileInfo(profileData) {
       const total = profileData.graduetescale.total;
       const percentage = Math.min((completed / total) * 100, 100).toFixed(2); // Limita a 100% e formata para 2 casas decimais
       progress.style.width = `${percentage}%`;
-      progressText.innerText = `${completed} disciplinas cursadas de ${total} (${percentage}%)`;
+      const progressLabel = profileData.translations.coursesCompletedText;
+      progressText.innerText = `${completed} ${progressLabel} ${total} (${percentage}%)`;
     }
   }
 
@@ -546,7 +547,7 @@ function calcularDuracao(periodo, traducoes) {
       duracao += `${anos} ${anos > 1 ? traducoes.years_plural : traducoes.years}`;
   }
   if (mesesDuracao > 0) {
-      if (anos > 0) duracao += " e ";
+      if (anos > 0) duracao += ` ${traducoes.connector} `;
       duracao += `${mesesDuracao} ${mesesDuracao > 1 ? traducoes.months_plural : traducoes.months_text}`;
   }
   return duracao || traducoes.lessThanAMonth;

--- a/data/profile_en.json
+++ b/data/profile_en.json
@@ -28,7 +28,9 @@
     "years": "year",
     "years_plural": "years",
     "months_text": "month",
-    "months_plural": "months"
+    "months_plural": "months",
+    "connector": "and",
+    "coursesCompletedText": "subjects completed out of"
   },
   "location": "Brazil - RJ",
   "phone": "(21) 98030-9664",

--- a/data/profile_es.json
+++ b/data/profile_es.json
@@ -10,18 +10,18 @@
   },
   "translations": {
     "months": {
-      "january": 0,
-      "february": 1,
-      "march": 2,
-      "april": 3,
-      "may": 4,
-      "june": 5,
-      "july": 6,
-      "august": 7,
-      "september": 8,
-      "october": 9,
-      "november": 10,
-      "december": 11
+      "Enero": 0,
+      "Febrero": 1,
+      "Marzo": 2,
+      "Abril": 3,
+      "Mayo": 4,
+      "Junio": 5,
+      "Julio": 6,
+      "Agosto": 7,
+      "Septiembre": 8,
+      "Octubre": 9,
+      "Noviembre": 10,
+      "Diciembre": 11
     },
     "current": "hasta el momento",
     "lessThanAMonth": "Menos de un mes",
@@ -29,7 +29,8 @@
     "years_plural": "años",
     "months_text": "mes",
     "months_plural": "meses",
-    "connector": " y "
+    "connector": "y",
+    "coursesCompletedText": "asignaturas cursadas de"
   },
   "location": "Brasil - RJ",
   "phone": "(21) 98030-9664",

--- a/data/profile_pt.json
+++ b/data/profile_pt.json
@@ -28,7 +28,9 @@
     "years": "ano",
     "years_plural": "anos",
     "months_text": "mês",
-    "months_plural": "meses"
+    "months_plural": "meses",
+    "connector": "e",
+    "coursesCompletedText": "disciplinas cursadas de"
   },
   "location": "Brasil - RJ",
   "phone": "(21) 98030-9664",


### PR DESCRIPTION
## Summary
- detect browser language, set page lang and load matching profile
- add localized progress and duration text
- provide translations for Portuguese, English and Spanish

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check assets/js/api.js`
- `node --check assets/js/main.js`
- `jq . data/profile_pt.json`
- `jq . data/profile_en.json`
- `jq . data/profile_es.json`


------
https://chatgpt.com/codex/tasks/task_e_689bde8d95f4832ab227120660d3de4f