### PR TITLE
Rename graduetescale to graduateScale across project

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -351,15 +351,15 @@ function updateProfileInfo(profileData) {
   }
 
   // Atualizar a Barra de Progresso da Graduação
-  const graduetescaleContainer = document.getElementById(
-    "profile.graduetescale"
+  const graduateScaleContainer = document.getElementById(
+    "profile.graduateScale"
   );
-  if (graduetescaleContainer && profileData.graduetescale) {
-    const progress = graduetescaleContainer.querySelector(".progress");
-    const progressText = graduetescaleContainer.querySelector(".progress-text");
+  if (graduateScaleContainer && profileData.graduateScale) {
+    const progress = graduateScaleContainer.querySelector(".progress");
+    const progressText = graduateScaleContainer.querySelector(".progress-text");
     if (progress && progressText) {
-      const completed = profileData.graduetescale.completed;
-      const total = profileData.graduetescale.total;
+      const completed = profileData.graduateScale.completed;
+      const total = profileData.graduateScale.total;
       const percentage = Math.min((completed / total) * 100, 100).toFixed(2); // Limita a 100% e formata para 2 casas decimais
       progress.style.width = `${percentage}%`;
       progressText.innerText = `${completed} disciplinas cursadas de ${total} (${percentage}%)`;

--- a/data/profile_en.json
+++ b/data/profile_en.json
@@ -4,7 +4,7 @@
   "photo": "https://raw.githubusercontent.com/angelojbgama/sobremim/main/assets/img/my-photo.jpg",
   "job": "Programmer",
   "graduate": "Systems Analysis and Development",
-  "graduetescale": {
+  "graduateScale": {
     "completed": 15,
     "total": 35
   },

--- a/data/profile_es.json
+++ b/data/profile_es.json
@@ -4,7 +4,7 @@
   "photo": "https://raw.githubusercontent.com/angelojbgama/sobremim/main/assets/img/my-photo.jpg",
   "job": "Programador",
   "graduate": "Análisis y Desarrollo de Sistemas",
-  "graduetescale": {
+  "graduateScale": {
     "completed": 15,
     "total": 35
   },

--- a/data/profile_pt.json
+++ b/data/profile_pt.json
@@ -4,7 +4,7 @@
   "photo": "https://raw.githubusercontent.com/angelojbgama/sobremim/main/assets/img/my-photo.jpg",
   "job": "Programador",
   "graduate": "Analise e Desenvolvimento de Sistemas",
-  "graduetescale": {
+  "graduateScale": {
     "completed": 25,
     "total": 35
   },

--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
 
       <!-- Barra de Progresso da Graduação -->
 
-      <div class="progress-container" id="profile.graduetescale">
+      <div class="progress-container" id="profile.graduateScale">
 
         <div class="progress-bar">
 


### PR DESCRIPTION
## Summary
- Rename `graduetescale` identifiers to `graduateScale`
- Update graduation progress bar to use new naming

## Testing
- `python - <<'PY'
import json, re, sys
from pathlib import Path
html = Path('index.html').read_text()
print('hasID', 'profile.graduateScale' in html)
with open('data/profile_pt.json') as f:
    data = json.load(f)
completed = data['graduateScale']['completed']
total = data['graduateScale']['total']
percentage = min(completed/total*100, 100)
print('computed width', f'{percentage:.2f}%')
print('progress text', f'{completed} disciplinas cursadas de {total} ({percentage:.2f}%)')
PY`
- `python -m json.tool data/profile_pt.json >/dev/null && echo OK`
- `python -m json.tool data/profile_en.json >/dev/null && echo OK`
- `python -m json.tool data/profile_es.json >/dev/null && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_689bdef1cd40832aa472ab24ab2eeb46