### PR TITLE
fix: correct profile image path

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
 
     <img
 
-      src="../assets/img/my-photo.jpg"
+      src="assets/img/my-photo.jpg"
 
       alt="Foto de Perfil"
 


### PR DESCRIPTION
## Summary
- fix profile photo path to use correct relative path

## Testing
- `npx -y htmlhint index.html` (fails: 403 Forbidden)
- `curl -I http://localhost:8000/assets/img/my-photo.jpg`


------
https://chatgpt.com/codex/tasks/task_e_689bdefc6914832ab91cde2bccaa4f4f