### PR TITLE
Remove auto invocation of fetchProfileData example

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -30,13 +30,13 @@ async function fetchProfileData() {
     }
 }
 
-// Exemplo de uso da função
-fetchProfileData().then(profileData => {
-    if (profileData) {
-        // Aqui você pode manipular os dados do perfil e atualizar a interface da página
-        console.log(profileData);
-    } else {
-        // Lógica para caso os dados não sejam carregados
-        console.log("Não foi possível carregar os dados do perfil.");
-    }
-});
+// Exemplo de uso da função (não executado automaticamente)
+// fetchProfileData().then(profileData => {
+//     if (profileData) {
+//         // Aqui você pode manipular os dados do perfil e atualizar a interface da página
+//         console.log(profileData);
+//     } else {
+//         // Lógica para caso os dados não sejam carregados
+//         console.log("Não foi possível carregar os dados do perfil.");
+//     }
+// });


### PR DESCRIPTION
## Summary
- keep `fetchProfileData` as a callable utility without auto-running it
- clarify the example usage by commenting it out

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bdf14c9f8832abafa308edcb14e04