### PR TITLE
Add tests for fetchProfileData behavior

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -30,13 +30,20 @@ async function fetchProfileData() {
     }
 }
 
-// Exemplo de uso da função
-fetchProfileData().then(profileData => {
-    if (profileData) {
-        // Aqui você pode manipular os dados do perfil e atualizar a interface da página
-        console.log(profileData);
-    } else {
-        // Lógica para caso os dados não sejam carregados
-        console.log("Não foi possível carregar os dados do perfil.");
-    }
-});
+// Exporta a função para uso em testes ou outros módulos
+if (typeof module !== 'undefined') {
+    module.exports = { fetchProfileData };
+}
+
+// Exemplo de uso da função no navegador
+if (typeof window !== 'undefined') {
+    fetchProfileData().then(profileData => {
+        if (profileData) {
+            // Aqui você pode manipular os dados do perfil e atualizar a interface da página
+            console.log(profileData);
+        } else {
+            // Lógica para caso os dados não sejam carregados
+            console.log("Não foi possível carregar os dados do perfil.");
+        }
+    });
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "sobremim",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,0 +1,33 @@
+const { fetchProfileData } = require('../assets/js/api');
+
+describe('fetchProfileData', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('defaults to pt when language is unsupported and returns profile data', async () => {
+    const profilePt = require('../data/profile_pt.json');
+    global.navigator = { language: 'fr-FR', userLanguage: 'fr-FR' };
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(profilePt),
+      })
+    );
+
+    const data = await fetchProfileData();
+
+    expect(global.fetch).toHaveBeenCalledWith('data/profile_pt.json');
+    expect(data).toEqual(profilePt);
+  });
+
+  test('returns null when fetch fails', async () => {
+    global.navigator = { language: 'fr-FR', userLanguage: 'fr-FR' };
+    global.fetch = jest.fn(() => Promise.reject(new Error('Network error')));
+
+    const data = await fetchProfileData();
+
+    expect(global.fetch).toHaveBeenCalledWith('data/profile_pt.json');
+    expect(data).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- export fetchProfileData for external use and browser-only invocation
- add Jest tests covering default language and fetch failure scenarios

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bdf1aca24832aa8b95df5a3c769a6