### PR TITLE
Fix API module syntax and export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -16,7 +16,7 @@ async function fetchProfileData() {
 
     try {
         const response = await fetch(url);
-        
+
         if (!response.ok) {
             throw new Error(`Erro ao carregar o arquivo JSON: ${response.statusText}`);
         }
@@ -28,6 +28,8 @@ async function fetchProfileData() {
         // Opcional: Retornar dados padrão ou exibir uma mensagem de erro para o usuário
         return null;
     }
+}
+
 if (typeof window !== 'undefined') {
     fetchProfileData().then(profileData => {
         if (profileData) {
@@ -39,3 +41,5 @@ if (typeof window !== 'undefined') {
         }
     });
 }
+
+module.exports = { fetchProfileData };


### PR DESCRIPTION
## Summary
- properly close and export `fetchProfileData` in `api.js`
- add `.gitignore` to exclude `node_modules` and lock file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689be4315b64832a88692a57915c4475