### PR TITLE
Add UI translation framework with automatic language detection

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -1,45 +1,46 @@
-async function fetchProfileData() {
-    // Detecta o idioma do navegador
+function detectLanguage() {
     let language = navigator.language || navigator.userLanguage;
-    language = language.substring(0, 2).toLowerCase(); // Extrai o código do idioma (ex: 'pt', 'en', 'es')
-
-    // Lista de idiomas suportados
+    language = language.substring(0, 2).toLowerCase();
     const supportedLanguages = ['pt', 'en', 'es'];
-
-    // Verifica se o idioma detectado é suportado; caso contrário, define como padrão ('pt')
     if (!supportedLanguages.includes(language)) {
         language = 'pt';
     }
+    return language;
+}
 
-    // Define o caminho do arquivo JSON baseado no idioma
+async function fetchProfileData(lang) {
+    const language = lang || detectLanguage();
     const url = `data/profile_${language}.json`;
-
     try {
         const response = await fetch(url);
-
         if (!response.ok) {
             throw new Error(`Erro ao carregar o arquivo JSON: ${response.statusText}`);
         }
-
         const profileData = await response.json();
         return profileData;
     } catch (error) {
         console.error(error);
-        // Opcional: Retornar dados padrão ou exibir uma mensagem de erro para o usuário
         return null;
     }
 }
 
-if (typeof window !== 'undefined') {
-    fetchProfileData().then(profileData => {
-        if (profileData) {
-            // Aqui você pode manipular os dados do perfil e atualizar a interface da página
-            console.log(profileData);
-        } else {
-            // Lógica para caso os dados não sejam carregados
-            console.log("Não foi possível carregar os dados do perfil.");
+async function fetchUiText(lang) {
+    const language = lang || detectLanguage();
+    const url = `data/ui_${language}.json`;
+    try {
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`Erro ao carregar o arquivo de interface: ${response.statusText}`);
         }
-    });
+        const uiData = await response.json();
+        uiData.language = language;
+        return uiData;
+    } catch (error) {
+        console.error(error);
+        return { loading: "Loading...", profileLoadError: "Could not load profile data.", profileNotLoaded: "Profile data was not loaded.", language };
+    }
 }
 
-module.exports = { fetchProfileData };
+if (typeof module !== 'undefined') {
+    module.exports = { fetchProfileData, fetchUiText, detectLanguage };
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -606,8 +606,15 @@ function updateSkillTitles(profileData) {
 
 // --- Função Principal para Carregar e Atualizar o Perfil ---
 (async () => {
+  const uiText = await fetchUiText();
+  document.documentElement.lang = uiText.language;
+  document.title = uiText.loading;
+  document.querySelectorAll('.loading-text').forEach(el => {
+    el.innerText = uiText.loading;
+  });
+
   try {
-    const profileData = await fetchProfileData();
+    const profileData = await fetchProfileData(uiText.language);
     if (profileData) {
       updateProfileInfo(profileData);
       updateSoftSkills(profileData);
@@ -618,10 +625,10 @@ function updateSkillTitles(profileData) {
       updateAccordionTitles(profileData); // Atualizar títulos dos accordions
       updateSkillTitles(profileData); // Atualizar títulos das seções internas das habilidades
     } else {
-      console.error("Dados do perfil não foram carregados.");
+      console.error(uiText.profileNotLoaded);
     }
   } catch (error) {
-    console.error("Erro ao atualizar o perfil:", error);
+    console.error(uiText.profileLoadError, error);
   }
 })();
 

--- a/data/ui_en.json
+++ b/data/ui_en.json
@@ -1,0 +1,5 @@
+{
+  "loading": "Loading...",
+  "profileLoadError": "Could not load profile data.",
+  "profileNotLoaded": "Profile data was not loaded."
+}

--- a/data/ui_es.json
+++ b/data/ui_es.json
@@ -1,0 +1,5 @@
+{
+  "loading": "Cargando...",
+  "profileLoadError": "No se pudo cargar los datos del perfil.",
+  "profileNotLoaded": "Los datos del perfil no se cargaron."
+}

--- a/data/ui_pt.json
+++ b/data/ui_pt.json
@@ -1,0 +1,5 @@
+{
+  "loading": "Carregando...",
+  "profileLoadError": "Não foi possível carregar os dados do perfil.",
+  "profileNotLoaded": "Dados do perfil não foram carregados."
+}

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 
 <!-- Título da página -->
 
-<title>Carregando...</title>
+<title></title>
 
 
 
@@ -100,7 +100,7 @@
 
     <h1 class="title">
 
-      <span id="profile.name">Carregando...</span>
+      <span id="profile.name" class="loading-text"></span>
 
     </h1>
 
@@ -124,7 +124,7 @@
 
         ></i>
 
-        <span class="info-text">Carregando...</span>
+        <span class="info-text loading-text"></span>
 
       </p>
 
@@ -144,7 +144,7 @@
 
         ></i>
 
-        <span class="info-text">Carregando...</span>
+        <span class="info-text loading-text"></span>
 
       </p>
 
@@ -160,7 +160,7 @@
 
         </div>
 
-        <span class="progress-text">Carregando...</span>
+        <span class="progress-text loading-text"></span>
 
       </div>
 
@@ -180,7 +180,7 @@
 
         ></i>
 
-        <span class="info-text">Carregando...</span>
+        <span class="info-text loading-text"></span>
 
       </p>
 
@@ -200,7 +200,7 @@
 
         ></i>
 
-        <a href="" id="profile.phone" class="info-text">Carregando...</a>
+        <a href="" id="profile.phone" class="info-text loading-text"></a>
 
       </p>
 
@@ -220,11 +220,7 @@
 
         ></i>
 
-        <a href="mailto:ex@mail.com" id="profile.email" class="info-text">
-
-          Carregando...
-
-        </a>
+        <a href="mailto:ex@mail.com" id="profile.email" class="info-text loading-text"></a>
 
       </p>
 
@@ -275,7 +271,7 @@
 
     <button class="trigger" type="button">
 
-      <h2 id="acordeon.titleSkills">Carregando...</h2>
+      <h2 id="acordeon.titleSkills" class="loading-text"></h2>
 
     </button>
 
@@ -289,7 +285,7 @@
 
         <section class="tools">
 
-          <h3 id="skills.titleHardSkills">Carregando...</h3>
+          <h3 id="skills.titleHardSkills" class="loading-text"></h3>
 
           <ul id="profile.skills.hardSkills" class="hard-skills">
 
@@ -305,15 +301,15 @@
 
         <section class="personal">
 
-          <h3 id="skills.titleSoftSkills">Carregando...</h3>
+          <h3 id="skills.titleSoftSkills" class="loading-text"></h3>
 
           <ul id="profile.skills.softSkills">
 
-            <li>Carregando...</li>
+            <li class="loading-text"></li>
 
-            <li>Carregando...</li>
+            <li class="loading-text"></li>
 
-            <li>Carregando...</li>
+            <li class="loading-text"></li>
 
           </ul>
 
@@ -333,7 +329,7 @@
 
     <button class="trigger" type="button">
 
-      <h2 id="acordeon.titleLanguages">Carregando...</h2>
+      <h2 id="acordeon.titleLanguages" class="loading-text"></h2>
 
     </button>
 
@@ -343,7 +339,7 @@
 
       <ul class="languages" id="profile.languages">
 
-        <li>Carregando...</li>
+        <li class="loading-text"></li>
 
       </ul>
 
@@ -359,7 +355,7 @@
 
     <button class="trigger" type="button">
 
-      <h2 id="acordeon.titlePortfolio">Carregando...</h2>
+      <h2 id="acordeon.titlePortfolio" class="loading-text"></h2>
 
     </button>
 
@@ -385,7 +381,7 @@
 
     <button class="trigger" type="button">
 
-      <h2 id="acordeon.titleProfessionalExperience">Carregando...</h2>
+      <h2 id="acordeon.titleProfessionalExperience" class="loading-text"></h2>
 
     </button>
 

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,4 +1,4 @@
-const { fetchProfileData } = require('../assets/js/api');
+const { fetchProfileData, fetchUiText } = require('../assets/js/api');
 
 describe('fetchProfileData', () => {
   beforeEach(() => {
@@ -29,5 +29,38 @@ describe('fetchProfileData', () => {
 
     expect(global.fetch).toHaveBeenCalledWith('data/profile_pt.json');
     expect(data).toBeNull();
+  });
+});
+
+describe('fetchUiText', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('defaults to pt when language is unsupported and returns ui text', async () => {
+    const uiPt = require('../data/ui_pt.json');
+    global.navigator = { language: 'fr-FR', userLanguage: 'fr-FR' };
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(uiPt),
+      })
+    );
+
+    const data = await fetchUiText();
+
+    expect(global.fetch).toHaveBeenCalledWith('data/ui_pt.json');
+    expect(data).toEqual({ ...uiPt, language: 'pt' });
+  });
+
+  test('returns fallback when fetch fails', async () => {
+    global.navigator = { language: 'fr-FR', userLanguage: 'fr-FR' };
+    global.fetch = jest.fn(() => Promise.reject(new Error('Network error')));
+
+    const data = await fetchUiText();
+
+    expect(global.fetch).toHaveBeenCalledWith('data/ui_pt.json');
+    expect(data.loading).toBe('Loading...');
+    expect(data.language).toBe('pt');
   });
 });


### PR DESCRIPTION
## Summary
- Replace hardcoded page text with `loading-text` placeholders for translation
- Detect browser language and load matching UI strings and profile data
- Cover new translation loader with tests and JSON resources

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689be6839f20832a9ab2600c70249016