### PR TITLE
fix: improve portfolio icons and hover

### DIFF
--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -416,18 +416,18 @@ footer a:hover {
   flex-direction: column;
   justify-content: flex-start;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  transition: transform 0.2s;
+  transition: box-shadow 0.2s;
 }
 
 .portfolio li:hover {
-  transform: translateY(-4px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
 
 .portfolio li h3 {
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   font-size: 1.1rem;
   font-weight: 700;
   margin: 0 0 0.5rem;
@@ -438,10 +438,14 @@ footer a:hover {
   margin-right: 0.5rem;
 }
 
-.portfolio li a {
+.portfolio li a.portfolio-link {
   word-break: break-all;
   color: var(--text-color);
   font-size: 0.9rem;
+}
+
+.portfolio li h3 a:hover {
+  text-decoration: none;
 }
 
 /* ===========================================================

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -479,19 +479,15 @@ function updatePortfolio(profileData) {
   if (portfolio) {
     portfolio.innerHTML = profileData.portfolio
       .map((project) => {
-        // Ícone principal indica se o link é para o GitHub ou externo
-        const iconClass = project.github ? "fab fa-github" : "fas fa-link";
-        // Ícone adicional clicável para o GitHub
-        const githubLink = project.github
+        const iconHTML = project.github
           ? `<a href="${project.url}" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
                <i class="fab fa-github"></i>
              </a>`
-          : "";
+          : `<i class="fas fa-link"></i>`;
         return `
           <li class="portfolio-item">
             <h3 class="portfolio-title">
-              <i class="${iconClass}"></i> ${project.name}
-              ${githubLink}
+              ${iconHTML} ${project.name}
             </h3>
             <a href="${project.url}" target="_blank" rel="noopener noreferrer" class="portfolio-link">${project.url}</a>
           </li>


### PR DESCRIPTION
## Summary
- remove duplicated GitHub icons in portfolio entries
- prevent portfolio cards from moving upward on hover

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bee3f6a0c832aa86fb3538b68a26f