### PR TITLE
Position PDF download button on left side

### DIFF
--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -538,7 +538,7 @@ footer a:hover {
 .download-pdf {
   position: absolute;
   top: 1rem;
-  right: 4rem;
+  left: 1rem;
   background: none;
   border: none;
   cursor: pointer;
@@ -652,6 +652,11 @@ footer,
     list-style: none;
     padding: 0;
     margin: 0;
+  }
+
+  .download-pdf {
+    top: 0rem;
+    left: 0rem;
   }
 
   .theme-toggle {


### PR DESCRIPTION
## Summary
- Move PDF download button to the left edge of the header
- Ensure responsive layout keeps PDF button opposite theme toggle on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bf7af217c832a822adfeec1963d0e