### PR TITLE
Include full site details in generated PDF resume

### DIFF
--- a/assets/js/pdf.js
+++ b/assets/js/pdf.js
@@ -10,29 +10,87 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const name = document.getElementById("profile.name")?.innerText || "";
     const job = document.getElementById("profile.job")?.innerText || "";
+    const graduate =
+      document.querySelector("#profile.graduate .info-text")?.innerText || "";
+    const graduateProgress =
+      document.querySelector("#profile.graduateScale .progress-text")?.innerText ||
+      "";
     const location = document.getElementById("profile.location")?.innerText || "";
     const phone = document.getElementById("profile.phone")?.innerText || "";
     const email = document.getElementById("profile.email")?.innerText || "";
     const about = document.getElementById("profile.description")?.innerText || "";
 
-    const collectItems = (id) =>
+    const collectListItems = (id) =>
       Array.from(document.getElementById(id)?.querySelectorAll("li") || []).map(
         (li) => li.innerText.trim()
       );
 
-    const hardSkills = collectItems("profile.skills.hardSkills");
-    const softSkills = collectItems("profile.skills.softSkills");
-    const languages = collectItems("profile.languages");
-    const experiences = collectItems("profile.professionalExperience");
+    const collectPortfolio = () =>
+      Array.from(
+        document.getElementById("profile.portfolio")?.querySelectorAll("li") || []
+      ).map((li) => ({
+        title: li.querySelector(".portfolio-title")?.innerText.trim() || "",
+        link: li.querySelector(".portfolio-link")?.innerText.trim() || "",
+      }));
+
+    const collectExperiences = () =>
+      Array.from(
+        document
+          .getElementById("profile.professionalExperience")
+          ?.querySelectorAll("li") || []
+      ).map((li) => ({
+        title: li.querySelector(".title")?.innerText.trim() || "",
+        period: li.querySelector(".period")?.innerText.trim() || "",
+        description:
+          li.querySelector(".description")?.innerText.trim() || "",
+      }));
+
+    const hardSkills = collectListItems("profile.skills.hardSkills");
+    const softSkills = collectListItems("profile.skills.softSkills");
+    const languages = collectListItems("profile.languages");
+    const portfolio = collectPortfolio();
+    const experiences = collectExperiences();
+
+    const hardSkillsTitle =
+      document.getElementById("skills.titleHardSkills")?.innerText ||
+      "Hard Skills";
+    const softSkillsTitle =
+      document.getElementById("skills.titleSoftSkills")?.innerText ||
+      "Soft Skills";
+    const languagesTitle =
+      document.getElementById("acordeon.titleLanguages")?.innerText || "Idiomas";
+    const portfolioTitle =
+      document.getElementById("acordeon.titlePortfolio")?.innerText ||
+      "Portfólio";
+    const experienceTitle =
+      document.getElementById("acordeon.titleProfessionalExperience")
+        ?.innerText || "Experiência Profissional";
 
     let y = 10;
+    const pageHeight = doc.internal.pageSize.getHeight();
+    const checkPageBreak = (space = 10) => {
+      if (y + space > pageHeight - 10) {
+        doc.addPage();
+        y = 10;
+      }
+    };
+
     doc.setFontSize(16);
     doc.text(name, 10, y);
     y += 10;
     doc.setFontSize(12);
-    doc.text(job, 10, y);
-    y += 10;
-
+    if (job) {
+      doc.text(job, 10, y);
+      y += 10;
+    }
+    if (graduate) {
+      doc.text(`Formação: ${graduate}`, 10, y);
+      y += 10;
+    }
+    if (graduateProgress) {
+      doc.text(graduateProgress, 10, y);
+      y += 10;
+    }
     if (location) {
       doc.text(`Localização: ${location}`, 10, y);
       y += 10;
@@ -50,25 +108,74 @@ document.addEventListener("DOMContentLoaded", () => {
       doc.text("Sobre", 10, y);
       y += 10;
       const aboutLines = doc.splitTextToSize(about, 180);
-      doc.text(aboutLines, 10, y);
-      y += aboutLines.length * 10;
+      aboutLines.forEach((line) => {
+        checkPageBreak();
+        doc.text(line, 10, y);
+        y += 10;
+      });
     }
 
     const addList = (title, items) => {
       if (!items.length) return;
+      checkPageBreak();
       doc.text(title, 10, y);
       y += 10;
       items.forEach((item) => {
         const lines = doc.splitTextToSize(`- ${item}`, 180);
-        doc.text(lines, 10, y);
-        y += lines.length * 10;
+        lines.forEach((line) => {
+          checkPageBreak();
+          doc.text(line, 10, y);
+          y += 10;
+        });
       });
     };
 
-    addList("Hard Skills", hardSkills);
-    addList("Soft Skills", softSkills);
-    addList("Idiomas", languages);
-    addList("Experiência Profissional", experiences);
+    const addPortfolio = (title, items) => {
+      if (!items.length) return;
+      checkPageBreak();
+      doc.text(title, 10, y);
+      y += 10;
+      items.forEach((item) => {
+        const line = `- ${item.title}: ${item.link}`.trim();
+        const lines = doc.splitTextToSize(line, 180);
+        lines.forEach((l) => {
+          checkPageBreak();
+          doc.text(l, 10, y);
+          y += 10;
+        });
+      });
+    };
+
+    const addExperiences = (title, items) => {
+      if (!items.length) return;
+      checkPageBreak();
+      doc.text(title, 10, y);
+      y += 10;
+      items.forEach((exp) => {
+        checkPageBreak();
+        doc.text(`- ${exp.title}`, 10, y);
+        y += 10;
+        if (exp.period) {
+          checkPageBreak();
+          doc.text(`  ${exp.period}`, 10, y);
+          y += 10;
+        }
+        if (exp.description) {
+          const lines = doc.splitTextToSize(`  ${exp.description}`, 180);
+          lines.forEach((line) => {
+            checkPageBreak();
+            doc.text(line, 10, y);
+            y += 10;
+          });
+        }
+      });
+    };
+
+    addList(hardSkillsTitle, hardSkills);
+    addList(softSkillsTitle, softSkills);
+    addList(languagesTitle, languages);
+    addPortfolio(portfolioTitle, portfolio);
+    addExperiences(experienceTitle, experiences);
 
     doc.save("curriculo.pdf");
   });


### PR DESCRIPTION
## Summary
- expand PDF generator to include graduation, progress, portfolio, and detailed experience sections
- pull section titles from the page and manage page breaks for multi-section documents

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bfba639c4832aa4ddb531f6dd8be8