### PR TITLE
Ensure unsupported language codes fall back to Portuguese

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -1,5 +1,5 @@
-function detectLanguage() {
-    let language = navigator.language || navigator.userLanguage;
+function detectLanguage(lang) {
+    let language = lang || navigator.language || navigator.userLanguage;
     language = language.substring(0, 2).toLowerCase();
     const supportedLanguages = ['pt', 'en', 'es'];
     if (!supportedLanguages.includes(language)) {
@@ -9,7 +9,7 @@ function detectLanguage() {
 }
 
 async function fetchProfileData(lang) {
-    const language = lang || detectLanguage();
+    const language = detectLanguage(lang);
     const url = `data/profile_${language}.json`;
     try {
         const response = await fetch(url);
@@ -25,7 +25,7 @@ async function fetchProfileData(lang) {
 }
 
 async function fetchUiText(lang) {
-    const language = lang || detectLanguage();
+    const language = detectLanguage(lang);
     const url = `data/ui_${language}.json`;
     try {
         const response = await fetch(url);

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -30,6 +30,21 @@ describe('fetchProfileData', () => {
     expect(global.fetch).toHaveBeenCalledWith('data/profile_pt.json');
     expect(data).toBeNull();
   });
+
+  test('falls back to pt when explicit language is unsupported', async () => {
+    const profilePt = require('../data/profile_pt.json');
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(profilePt),
+      })
+    );
+
+    const data = await fetchProfileData('fr');
+
+    expect(global.fetch).toHaveBeenCalledWith('data/profile_pt.json');
+    expect(data).toEqual(profilePt);
+  });
 });
 
 describe('fetchUiText', () => {
@@ -62,5 +77,20 @@ describe('fetchUiText', () => {
     expect(global.fetch).toHaveBeenCalledWith('data/ui_pt.json');
     expect(data.loading).toBe('Loading...');
     expect(data.language).toBe('pt');
+  });
+
+  test('falls back to pt when explicit language is unsupported', async () => {
+    const uiPt = require('../data/ui_pt.json');
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(uiPt),
+      })
+    );
+
+    const data = await fetchUiText('fr');
+
+    expect(global.fetch).toHaveBeenCalledWith('data/ui_pt.json');
+    expect(data).toEqual({ ...uiPt, language: 'pt' });
   });
 });


### PR DESCRIPTION
## Summary
- Normalize language detection to handle provided codes and fall back to Portuguese when unsupported
- Test fetchProfileData and fetchUiText with explicit unsupported language codes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c47c99cac832a8976e0ca125702d0